### PR TITLE
Adding label support to assembler

### DIFF
--- a/pyevmasm/evmasm.py
+++ b/pyevmasm/evmasm.py
@@ -491,7 +491,7 @@ def disassemble_one(bytecode, pc=0, fork=DEFAULT_FORK):
         return instruction
 
 
-def disassemble_all(bytecode, pc=0, fork=DEFAULT_FORK):
+def disassemble_all(bytecode, pc=1, fork=DEFAULT_FORK):
     """ Disassemble all instructions in bytecode
 
         :param bytecode: an evm bytecode (binary)

--- a/pyevmasm/evmasm.py
+++ b/pyevmasm/evmasm.py
@@ -329,7 +329,17 @@ class Instruction(object):
             'ADD', 'MUL', 'SUB', 'DIV', 'SDIV', 'MOD', 'SMOD', 'ADDMOD', 'MULMOD', 'EXP', 'SIGNEXTEND', 'SHL', 'SHR', 'SAR'}
 
 
-def assemble_one(asmcode, pc=0, fork=DEFAULT_FORK):
+def is_push(instr):
+    return (instr._opcode >= 0x60) and (instr._opcode <= 0x6F)
+
+def is_digit(operand):
+    try:
+        int(operand, 0)
+        return True
+    except:
+        return False
+
+def assemble_one(asmcode, pc=0, fork=DEFAULT_FORK, fillins={}):
     """ Assemble one EVM instruction from its textual representation.
 
         :param asmcode: assembly code for one instruction
@@ -355,13 +365,25 @@ def assemble_one(asmcode, pc=0, fork=DEFAULT_FORK):
             instr.pc = pc
         if instr.operand_size > 0:
             assert len(asmcode) == 2
-            instr.operand = int(asmcode[1], 0)
+            operand = asmcode[1]
+            if is_push(instr) and not is_digit(operand):
+                # instantiating a label, fill it with zeros instead
+                instr.operand = 0
+                if operand in fillins:
+                    fillins[operand].append(pc)
+                else:
+                    fillins[operand] = [pc]
+            else:
+                instr.operand = int(asmcode[1], 0)
         return instr
     except:
         raise AssembleError("Something wrong at pc %d" % pc)
 
+def fixup_instr(instr, label_offset):
+    assert is_push(instr)
+    instr.operand = label_offset
 
-def assemble_all(asmcode, pc=0, fork=DEFAULT_FORK):
+def assemble_all(asmcode, pc=1, fork=DEFAULT_FORK):
     """ Assemble a sequence of textual representation of EVM instructions
 
         :param asmcode: assembly code for any number of instructions
@@ -390,13 +412,39 @@ def assemble_all(asmcode, pc=0, fork=DEFAULT_FORK):
     """
     asmcode = asmcode.split('\n')
     asmcode = iter(asmcode)
+ 
+    # we use a dictionary to record label locations:
+    labels = {}
+    # another dictionary to record which instruction
+    # we need to fill in.
+    fillins = {}
+    # we have to traverse the generated instruction twice
+    # so no use of generator here
+    instrs = []
+
     for line in asmcode:
         if not line.strip():
             continue
-        instr = assemble_one(line, pc=pc, fork=fork)
-        yield instr
+        if line.endswith(":"):
+            # this is a label, record it with location (PC)
+            labels[line[:-1]] = pc
+            continue
+        instr = assemble_one(line, pc=pc, fork=fork, fillins=fillins)
+        instrs.append(instr)
         pc += instr.size
 
+    # fixup instructions
+    for label in labels:
+        if label not in fillins.keys():
+            continue
+        for instr in instrs:
+            if instr._pc in fillins[label]:
+                label_pc = labels[label]
+                fixup_instr(instr, label_pc)
+
+    # to keep it compatible with existing APIs
+    for instr in instrs:
+        yield instr
 
 def disassemble_one(bytecode, pc=0, fork=DEFAULT_FORK):
     """ Disassemble a single instruction from a bytecode
@@ -513,7 +561,7 @@ def disassemble(bytecode, pc=0, fork=DEFAULT_FORK):
     return '\n'.join(map(str, disassemble_all(bytecode, pc=pc, fork=fork)))
 
 
-def assemble(asmcode, pc=0, fork=DEFAULT_FORK):
+def assemble(asmcode, pc=1, fork=DEFAULT_FORK):
     """ Assemble an EVM program
 
         :param asmcode: an evm assembler program

--- a/tests/test_EVMAssembler.py
+++ b/tests/test_EVMAssembler.py
@@ -43,6 +43,30 @@ class EVMTest_Assembler(unittest.TestCase):
         asmcode = EVMAsm.disassemble_hex('0x608040526002610100')
         self.assertEqual(asmcode, '''PUSH1 0x80\nBLOCKHASH\nMSTORE\nPUSH1 0x2\nPUSH2 0x100''')
 
+    def test_label(self):
+        bytecode = EVMAsm.assemble_hex("""
+Start:
+    PUSH1 Return
+    PUSH1 0x11
+    PUSH1 0x22
+    PUSH2 Function
+    JUMP
+Return:
+    JUMPDEST
+    PUSH1 0x00
+    MSTORE
+    PUSH1 0x20
+    PUSH1 0x00
+    RETURN
+Function:
+    JUMPDEST
+    ADD
+    SWAP1
+    JUMP
+        """)
+        self.assertEqual(bytecode,
+                         '0x600a60116022610013565b60005260206000f35b019056')
+
     def test_STOP(self):
         insn = EVMAsm.disassemble_one(b'\x00')
         self.assertTrue(insn.mnemonic == 'STOP')


### PR DESCRIPTION
I would like to use this little tool to do some easy assembling in my project but found that this does not support label syntax, such as:
```
    ...
some_label:
    JUMPDEST
    ...
    PUSH some_label
    JUMP
```

So I just added the labeling syntax.

Another thing is that it seems that EVM memory space address starts with 1 rather than 0. So I changed `pc` according.