### PR TITLE
Add 'SHA3' to 'reads_from_memory'

### DIFF
--- a/pyevmasm/evmasm.py
+++ b/pyevmasm/evmasm.py
@@ -302,6 +302,7 @@ class Instruction(object):
     def reads_from_memory(self):
         """ True if the instruction reads from memory """
         return self.semantics in {
+            "SHA3",
             "MLOAD",
             "CREATE",
             "CALL",


### PR DESCRIPTION
Tiny chnage to have `reads_from_memory` return `True` for SHA3 instructions.
(SHA3's operands from the stack are memory addresses)