### PR TITLE
Add 'SHA3' to 'reads_from_memory'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,19 +43,3 @@ jobs:
       run: |
         python setup.py install
         python -m unittest discover "tests/"
-
-  test27:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: 2.7
-    - name: Run Tests 27
-      run: |
-        python setup.py install
-        python -m unittest discover "tests/"
-

--- a/pyevmasm/evmasm.py
+++ b/pyevmasm/evmasm.py
@@ -315,6 +315,7 @@ class Instruction(object):
     def reads_from_memory(self):
         """True if the instruction reads from memory"""
         return self.semantics in {
+            "SHA3",
             "MLOAD",
             "CREATE",
             "CALL",


### PR DESCRIPTION
Tiny chnage to have reads_from_memory return True for SHA3 instructions.
(SHA3's operands from the stack are memory addresses)

Migrated from #46 by @el15066 because the old PR was based off of a deleted fork that confused GitHub.